### PR TITLE
Fixes BaseProvider not found

### DIFF
--- a/GithubPlugin.php
+++ b/GithubPlugin.php
@@ -16,6 +16,7 @@ class GithubPlugin extends BasePlugin
      */
     public function getOAuthProviders()
     {
+        require_once(CRAFT_PLUGINS_PATH.'oauth/providers/BaseProvider.php');
         require_once(CRAFT_PLUGINS_PATH.'github/providers/oauth/Github.php');
 
         return [


### PR DESCRIPTION
When enabling this plugin you couldn't visit the OAuth settings page in Craft.

Copied from [this pull request](https://github.com/dukt/craft-linkedin/pull/2) by @luwes for the craft-linkedin plugin